### PR TITLE
Add test for validateCV file comparison using JSON JD and PDF CV

### DIFF
--- a/tests/fixtures/cv.pdf
+++ b/tests/fixtures/cv.pdf
@@ -1,0 +1,36 @@
+%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 300 144] /Contents 4 0 R >>
+endobj
+4 0 obj
+<< /Length 44 >>
+stream
+BT
+/F1 24 Tf
+100 100 Td
+(Sample CV text) Tj
+ET
+endstream
+endobj
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000010 00000 n 
+0000000060 00000 n 
+0000000117 00000 n 
+0000000190 00000 n 
+0000000307 00000 n 
+trailer
+<< /Root 1 0 R /Size 6 >>
+startxref
+375
+%%EOF

--- a/tests/fixtures/jd.json
+++ b/tests/fixtures/jd.json
@@ -1,0 +1,3 @@
+{
+  "jdExtractedText": "Sample job description from JSON."
+}

--- a/tests/validateCV.test.js
+++ b/tests/validateCV.test.js
@@ -1,0 +1,58 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+// Make path and fs available globally since jobController expects them
+global.path = path;
+global.fs = fs;
+
+// Read sample files
+const jdPath = path.join(__dirname, 'fixtures/jd.json');
+const cvPath = path.join(__dirname, 'fixtures/cv.pdf');
+const jdText = JSON.parse(fs.readFileSync(jdPath, 'utf8')).jdExtractedText;
+const cvText = 'Sample CV text';
+
+// Stub models and helpers
+const Job = {
+  findById: async () => ({ jdExtractedText: jdText })
+};
+const User = {
+  findById: async () => ({ cvFile: 'tests/fixtures/cv.pdf' })
+};
+global.User = User;
+
+global.extractText = async filePath => {
+  if (filePath === cvPath) {
+    return cvText;
+  }
+  throw new Error('Unexpected file path');
+};
+
+const compareWithChat = async (jd, cv) => {
+  compareWithChat.calledWith = [jd, cv];
+  return { canApply: true, score: 95, reasons: ['match'] };
+};
+
+// Inject stubs into require cache
+const jobModelPath = path.join(__dirname, '../src/models/jobModel.js');
+require.cache[jobModelPath] = { exports: Job };
+
+const geminiHelperPath = path.join(__dirname, '../src/utils/geminiHelper.js');
+require.cache[geminiHelperPath] = { exports: { compareWithChat, getEmbedding: () => {} } };
+
+// Now require the controller
+const { validateCV } = require('../src/controllers/jobController');
+
+(async () => {
+  const req = { params: { jobId: '1' }, session: { userId: 'u1' } };
+  const res = { json: data => { res.body = data; } };
+  const next = err => { throw err; };
+
+  await validateCV(req, res, next);
+
+  assert.deepStrictEqual(compareWithChat.calledWith, [jdText, cvText]);
+  assert.strictEqual(res.body.jobId, '1');
+  assert.strictEqual(res.body.userId, 'u1');
+  assert.strictEqual(res.body.canApply, true);
+  console.log('validateCV test passed');
+})();


### PR DESCRIPTION
## Summary
- replace text fixtures with `jd.json` and `cv.pdf`
- update `validateCV` test to parse JSON and stub PDF text extraction

## Testing
- `node tests/validateCV.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a67baabe6c8330a88651008cc84564