### PR TITLE
feat: persist CV text on user model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
         "express-validator": "^6.14.2",
         "mongoose": "^7.3.1",
         "multer": "^2.0.0",
-        "nodemailer": "^7.0.3"
+        "nodemailer": "^7.0.3",
+        "pdf-parse": "^1.1.1"
       },
       "devDependencies": {
         "nodemon": "^2.0.22"
@@ -2674,6 +2675,12 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-ensure": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/node-ensure/-/node-ensure-0.0.0.tgz",
+      "integrity": "sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==",
+      "license": "MIT"
+    },
     "node_modules/node-fetch": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
@@ -2816,6 +2823,28 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ=="
+    },
+    "node_modules/pdf-parse": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pdf-parse/-/pdf-parse-1.1.1.tgz",
+      "integrity": "sha512-v6ZJ/efsBpGrGGknjtq9J/oC8tZWq0KWL5vQrk2GlzLEQPUDB1ex+13Rmidl1neNN358Jn9EHZw5y07FFtaC7A==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^3.1.0",
+        "node-ensure": "^0.0.0"
+      },
+      "engines": {
+        "node": ">=6.8.1"
+      }
+    },
+    "node_modules/pdf-parse/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "express-validator": "^6.14.2",
     "mongoose": "^7.3.1",
     "multer": "^2.0.0",
-    "nodemailer": "^7.0.3"
+    "nodemailer": "^7.0.3",
+    "pdf-parse": "^1.1.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.22"

--- a/src/controllers/authController.js
+++ b/src/controllers/authController.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const path = require('path');
 const User   = require('../models/userModel');
 const { sendEmail } = require('../utils/email');
+const { extractText } = require('../utils/pdfExtractor');
 
 /**
  * @desc   Get current user’s info (except password)
@@ -153,9 +154,14 @@ exports.uploadCv = async (req, res, next) => {
 
     // 4) Save new file’s relative path in DB
     //    req.file.path is absolute or relative depending on multer; we store a relative path
-    const relativePath = path.relative(path.join(__dirname, '../..'), req.file.path);
-    user.cvFile = relativePath;
-    await user.save();
+      const relativePath = path.relative(path.join(__dirname, '../..'), req.file.path);
+      user.cvFile = relativePath;
+
+      // Extract text from uploaded CV and store it
+      const cvText = await extractText(req.file.path);
+      user.cvExtractedText = cvText;
+
+      await user.save();
 
     // 5) Respond with success
     return res.json({

--- a/src/controllers/jobController.js
+++ b/src/controllers/jobController.js
@@ -1,6 +1,11 @@
 // src/controllers/jobController.js
+const fs = require('fs');
+const path = require('path');
 const Job = require('../models/jobModel');
-const { getEmbedding, compareWithChat } = require('../utils/geminiHelper');
+const { compareWithChat } = require('../utils/geminiHelper');
+const { extractText } = require('../utils/pdfExtractor');
+
+const User = global.User || require('../models/userModel');
 
 exports.validateCV = async (req, res, next) => {
   try {
@@ -13,18 +18,23 @@ exports.validateCV = async (req, res, next) => {
       return res.status(404).json({ message: 'Job no encontrado o sin texto de JD.' });
     }
 
-    // 2) Fetch user and ensure CV exists
-    const user = await User.findById(userId);
-    if (!user || !user.cvFile) {
-      return res.status(404).json({ message: 'Usuario no encontrado o sin CV subido.' });
-    }
+      // 2) Fetch user and ensure CV exists
+      const user = await User.findById(userId);
+      if (!user || !user.cvFile) {
+        return res.status(404).json({ message: 'Usuario no encontrado o sin CV subido.' });
+      }
 
-    // 3) Extract text from the CV PDF
-    const cvPath = path.join(__dirname, '../..', user.cvFile);
-    if (!fs.existsSync(cvPath)) {
-      return res.status(404).json({ message: 'Archivo CV no encontrado en el servidor.' });
-    }
-    const cvText = await extractText(cvPath);
+      // 3) Obtain CV text, extracting if necessary
+      let cvText = user.cvExtractedText;
+      if (!cvText) {
+        const cvPath = path.join(__dirname, '../..', user.cvFile);
+        if (!fs.existsSync(cvPath)) {
+          return res.status(404).json({ message: 'Archivo CV no encontrado en el servidor.' });
+        }
+        cvText = await extractText(cvPath);
+        user.cvExtractedText = cvText;
+        await user.save();
+      }
 
     // 4) Ask Gemini (via GenAI SDK) to compare
     const result = await compareWithChat(job.jdExtractedText, cvText);

--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -9,6 +9,7 @@ const userSchema = new mongoose.Schema({
   confirmationToken:     { type: String },
   confirmationTokenExpires: { type: Date },
   cvFile:                  { type: String },
+  cvExtractedText:        { type: String },
 }, { timestamps: true });
 
 module.exports = mongoose.model('User', userSchema);

--- a/src/utils/pdfExtractor.js
+++ b/src/utils/pdfExtractor.js
@@ -1,0 +1,21 @@
+const fs = require('fs');
+const path = require('path');
+
+let extractText;
+
+if (global.extractText) {
+  extractText = global.extractText;
+} else {
+  const pdfParse = require('pdf-parse');
+
+  extractText = async (pdfPath) => {
+    const dataBuffer = fs.readFileSync(pdfPath);
+    const { text } = await pdfParse(dataBuffer);
+    const jsonPath = pdfPath.replace(/\.pdf$/i, '.json');
+    const payload = { cvExtractedText: text };
+    fs.writeFileSync(jsonPath, JSON.stringify(payload, null, 2));
+    return text;
+  };
+}
+
+module.exports = { extractText };

--- a/tests/validateCV.test.js
+++ b/tests/validateCV.test.js
@@ -16,8 +16,12 @@ const cvText = 'Sample CV text';
 const Job = {
   findById: async () => ({ jdExtractedText: jdText })
 };
+const userDoc = {
+  cvFile: 'tests/fixtures/cv.pdf',
+  async save() { this.saved = true; }
+};
 const User = {
-  findById: async () => ({ cvFile: 'tests/fixtures/cv.pdf' })
+  findById: async () => userDoc
 };
 global.User = User;
 
@@ -54,5 +58,7 @@ const { validateCV } = require('../src/controllers/jobController');
   assert.strictEqual(res.body.jobId, '1');
   assert.strictEqual(res.body.userId, 'u1');
   assert.strictEqual(res.body.canApply, true);
+  assert.strictEqual(userDoc.cvExtractedText, cvText);
+  assert.strictEqual(userDoc.saved, true);
   console.log('validateCV test passed');
 })();


### PR DESCRIPTION
## Summary
- add `cvExtractedText` field to the user schema
- capture CV text on upload and store it with the user
- reuse stored CV text during validation, extracting only when missing

## Testing
- `node tests/validateCV.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a68565258c83309ab331eca4ec852d