### PR TITLE
Use user cvExtractedText for validateCV

### DIFF
--- a/src/models/userModel.js
+++ b/src/models/userModel.js
@@ -9,6 +9,7 @@ const userSchema = new mongoose.Schema({
   confirmationToken:     { type: String },
   confirmationTokenExpires: { type: Date },
   cvFile:                  { type: String },
+  cvExtractedText:         { type: String },
 }, { timestamps: true });
 
 module.exports = mongoose.model('User', userSchema);

--- a/tests/fixtures/jd.json
+++ b/tests/fixtures/jd.json
@@ -1,0 +1,4 @@
+{
+  "jdExtractedText": "Sample job description from JSON.",
+  "cvExtractedText": "Sample CV text from JSON."
+}

--- a/tests/validateCV.test.js
+++ b/tests/validateCV.test.js
@@ -1,0 +1,47 @@
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs');
+
+// Read sample data
+const jdPath = path.join(__dirname, 'fixtures/jd.json');
+const { jdExtractedText: jdText, cvExtractedText: cvText } = JSON.parse(
+  fs.readFileSync(jdPath, 'utf8')
+);
+
+// Stub models and helpers
+const Job = {
+  findById: async () => ({ jdExtractedText: jdText })
+};
+const User = { findById: async () => ({ cvExtractedText: cvText }) };
+
+const compareWithChat = async (jd, cv) => {
+  compareWithChat.calledWith = [jd, cv];
+  return { canApply: true, score: 95, reasons: ['match'] };
+};
+
+// Inject stubs into require cache
+const jobModelPath = path.join(__dirname, '../src/models/jobModel.js');
+require.cache[jobModelPath] = { exports: Job };
+
+const userModelPath = path.join(__dirname, '../src/models/userModel.js');
+require.cache[userModelPath] = { exports: User };
+
+const geminiHelperPath = path.join(__dirname, '../src/utils/geminiHelper.js');
+require.cache[geminiHelperPath] = { exports: { compareWithChat, getEmbedding: () => {} } };
+
+// Now require the controller
+const { validateCV } = require('../src/controllers/jobController');
+
+(async () => {
+  const req = { params: { jobId: '1' }, session: { userId: 'u1' } };
+  const res = { json: data => { res.body = data; } };
+  const next = err => { throw err; };
+
+  await validateCV(req, res, next);
+
+  assert.deepStrictEqual(compareWithChat.calledWith, [jdText, cvText]);
+  assert.strictEqual(res.body.jobId, '1');
+  assert.strictEqual(res.body.userId, 'u1');
+  assert.strictEqual(res.body.canApply, true);
+  console.log('validateCV test passed');
+})();


### PR DESCRIPTION
## Summary
- add `cvExtractedText` field to user model
- have `validateCV` use existing `cvExtractedText` before reading a CV file
- simplify `validateCV` test to load job and CV text from `jd.json` and stub the user model

## Testing
- `node tests/validateCV.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a67baabe6c8330a88651008cc84564