### PR TITLE
Fix CV validation dependencies and tests

### DIFF
--- a/src/controllers/jobController.js
+++ b/src/controllers/jobController.js
@@ -3,9 +3,8 @@ const fs = require('fs');
 const path = require('path');
 const Job = require('../models/jobModel');
 const User = require('../models/userModel');
-const { getEmbedding, compareWithChat } = require('../utils/geminiHelper');
-const path = require('path');
-const fs = require('fs');
+const { compareWithChat } = require('../utils/geminiHelper');
+const { extractText } = require('../utils/pdfExtractor');
 
 
 
@@ -35,6 +34,11 @@ exports.validateCV = async (req, res, next) => {
         return res.status(404).json({ message: 'Archivo CV no encontrado en el servidor.' });
       }
       cvText = await extractText(cvPath);
+      // Persist the extracted text for future requests
+      user.cvExtractedText = cvText;
+      if (typeof user.save === 'function') {
+        await user.save();
+      }
     }
 
     // 4) Ask Gemini (via GenAI SDK) to compare

--- a/tests/fixtures/jd.json
+++ b/tests/fixtures/jd.json
@@ -1,5 +1,4 @@
 {
   "jdExtractedText": "Sample job description from JSON.",
   "cvExtractedText": "Sample CV text from JSON."
-  "jdExtractedText": "Sample job description from JSON."
 }

--- a/tests/validateCV.test.js
+++ b/tests/validateCV.test.js
@@ -14,8 +14,15 @@ const Job = {
   findById: async () => ({ jdExtractedText: jdText })
 };
 
-const User = { findById: async () => ({ cvExtractedText: cvText }) };
+const userDoc = {
+  cvFile: 'tests/fixtures/cv.pdf',
+  async save() {
+    this.saved = true;
+  }
+};
+const User = { findById: async () => userDoc };
 
+global.extractText = async () => cvText;
 
 const compareWithChat = async (jd, cv) => {
   compareWithChat.calledWith = [jd, cv];
@@ -31,7 +38,10 @@ const userModelPath = path.join(__dirname, '../src/models/userModel.js');
 require.cache[userModelPath] = { exports: User };
 
 const geminiHelperPath = path.join(__dirname, '../src/utils/geminiHelper.js');
-require.cache[geminiHelperPath] = { exports: { compareWithChat, getEmbedding: () => {} } };
+require.cache[geminiHelperPath] = { exports: { compareWithChat } };
+
+const pdfExtractorPath = path.join(__dirname, '../src/utils/pdfExtractor.js');
+require.cache[pdfExtractorPath] = { exports: { extractText: global.extractText } };
 
 // Now require the controller
 const { validateCV } = require('../src/controllers/jobController');
@@ -51,4 +61,5 @@ const { validateCV } = require('../src/controllers/jobController');
   assert.strictEqual(userDoc.cvExtractedText, cvText);
   assert.strictEqual(userDoc.saved, true);
 
+  delete global.extractText;
 })();


### PR DESCRIPTION
## Summary
- remove duplicate imports and add missing PDF extractor in CV validation controller
- persist extracted CV text and save user document
- repair test fixtures and update tests to stub extractor and user model

## Testing
- `node tests/validateCV.test.js`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a69cb641788330affab76a019ccd56