### PR TITLE
Load JD JSON for CV comparison

### DIFF
--- a/src/controllers/jobController.js
+++ b/src/controllers/jobController.js
@@ -1,40 +1,31 @@
 // src/controllers/jobController.js
 const Job = require('../models/jobModel');
 const User = require('../models/userModel');
-const { getEmbedding, compareWithChat } = require('../utils/geminiHelper');
-const path = require('path');
-const fs = require('fs');
+const { compareWithChat } = require('../utils/geminiHelper');
 
 exports.validateCV = async (req, res, next) => {
   try {
     const { jobId } = req.params;
     const userId    = req.session.userId;
 
-    // 1) Fetch job and ensure JD text is available
+    // 1) Fetch job and ensure JD JSON is available
     const job = await Job.findById(jobId);
-    if (!job || !job.jdExtractedText) {
-      return res.status(404).json({ message: 'Job no encontrado o sin texto de JD.' });
+    if (!job || !job.jdExtractedJson) {
+      return res.status(404).json({ message: 'Job no encontrado o sin JSON de JD.' });
     }
 
     // 2) Fetch user and ensure CV text is available
     const user = await User.findById(userId);
-    if (!user || (!user.cvFile && !user.cvExtractedText)) {
-      return res.status(404).json({ message: 'Usuario no encontrado o sin CV subido.' });
+    if (!user || !user.cvExtractedText) {
+      return res.status(404).json({ message: 'Usuario no encontrado o sin CV procesado.' });
     }
 
-    // 3) Determine CV text
-    let cvText = user.cvExtractedText;
-    if (!cvText) {
-      const cvPath = path.join(__dirname, '../..', user.cvFile);
-      if (!fs.existsSync(cvPath)) {
-        return res.status(404).json({ message: 'Archivo CV no encontrado en el servidor.' });
-      }
-      cvText = await extractText(cvPath);
-    }
-
+    // 3) Grab CV text directly for comparison
+    const cvText = user.cvExtractedText;
+    const jdJson = JSON.stringify(job.jdExtractedJson);
 
     // 4) Ask Gemini (via GenAI SDK) to compare
-    const result = await compareWithChat(job.jdExtractedText, cvText);
+    const result = await compareWithChat(jdJson, cvText);
     // result should be { canApply, score, reasons }
 
     return res.json({

--- a/src/models/jobModel.js
+++ b/src/models/jobModel.js
@@ -7,6 +7,7 @@ const jobSchema = new mongoose.Schema({
   asignacionSalarial:   { type: Number, required: true },
   codigoEmpleo:{ type: String, required: true },
   descripcion:   { type: String, required: true },
+  jdExtractedJson: { type: mongoose.Schema.Types.Mixed },
   // add more fields as needed…
 });
 

--- a/tests/validateCV.test.js
+++ b/tests/validateCV.test.js
@@ -1,11 +1,12 @@
 const assert = require('assert');
 
-// Load sample data directly from JSON fixture
-const { jdExtractedText: jdText, cvExtractedText: cvText } = require('./fixtures/jd.json');
+// Sample data used in the test
+const jdJson = require('../uploads/fixtures/jd.json');
+const cvText = 'sample CV text';
 
 // Stub models and helpers
 const Job = {
-  findById: async () => ({ jdExtractedText: jdText })
+  findById: async () => ({ jdExtractedJson: jdJson })
 };
 
 const User = { findById: async () => ({ cvExtractedText: cvText }) };
@@ -31,12 +32,15 @@ const { validateCV } = require('../src/controllers/jobController');
 
 (async () => {
   const req = { params: { jobId: '1' }, session: { userId: 'u1' } };
-  const res = { json: data => { res.body = data; } };
+  const res = {
+    json: data => { res.body = data; },
+    status: () => res
+  };
   const next = err => { throw err; };
 
   await validateCV(req, res, next);
 
-  assert.deepStrictEqual(compareWithChat.calledWith, [jdText, cvText]);
+  assert.deepStrictEqual(compareWithChat.calledWith, [JSON.stringify(jdJson), cvText]);
   assert.strictEqual(res.body.jobId, '1');
   assert.strictEqual(res.body.userId, 'u1');
   assert.strictEqual(res.body.canApply, true);

--- a/uploads/fixtures/jd.json
+++ b/uploads/fixtures/jd.json
@@ -1,0 +1,3 @@
+{
+  "description": "sample JD text"
+}


### PR DESCRIPTION
## Summary
- Stringify `jdExtractedJson` from jobs and send to Gemini for CV comparison
- Persist `jdExtractedJson` in the job schema and read CV text from stored extraction
- Load job description JSON from `uploads/fixtures/jd.json` in the unit test

## Testing
- `node tests/validateCV.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a727f7140c8330a258522d8b61cd85