### PR TITLE
feat: sanitize pdf text newline

### DIFF
--- a/src/utils/pdfExtractor.js
+++ b/src/utils/pdfExtractor.js
@@ -8,13 +8,22 @@ if (global.extractText) {
 } else {
   const pdfParse = require('pdf-parse');
 
-  extractText = async (pdfPath) => {
+  /**
+   * Extract text from a PDF file and replace newline characters with the
+   * provided delimiter (default is a space).
+   *
+   * @param {string} pdfPath - Absolute path to the PDF file.
+   * @param {string} [delimiter=' '] - Delimiter used to replace newlines.
+   * @returns {Promise<string>} The extracted, filtered text.
+   */
+  extractText = async (pdfPath, delimiter = ' ') => {
     const dataBuffer = fs.readFileSync(pdfPath);
     const { text } = await pdfParse(dataBuffer);
+    const filteredText = text.replace(/\r?\n/g, delimiter);
     const jsonPath = pdfPath.replace(/\.pdf$/i, '.json');
-    const payload = { cvExtractedText: text };
+    const payload = { cvExtractedText: filteredText };
     fs.writeFileSync(jsonPath, JSON.stringify(payload, null, 2));
-    return text;
+    return filteredText;
   };
 }
 

--- a/tests/pdfExtractor.test.js
+++ b/tests/pdfExtractor.test.js
@@ -1,0 +1,35 @@
+const assert = require('assert');
+const fs = require('fs');
+const path = require('path');
+
+// Stub pdf-parse before requiring pdfExtractor
+const pdfParsePath = require.resolve('pdf-parse');
+require.cache[pdfParsePath] = {
+  exports: async () => ({ text: 'line1\nline2' })
+};
+
+const { extractText } = require('../src/utils/pdfExtractor');
+
+const dummyPdfPath = path.join(__dirname, 'fixtures', 'dummy.pdf');
+fs.writeFileSync(dummyPdfPath, 'dummy');
+
+(async () => {
+  try {
+    const defaultText = await extractText(dummyPdfPath);
+    assert.strictEqual(defaultText, 'line1 line2');
+
+    const pipeText = await extractText(dummyPdfPath, '|');
+    assert.strictEqual(pipeText, 'line1|line2');
+
+    const jsonPath = dummyPdfPath.replace(/\.pdf$/i, '.json');
+    const payload = JSON.parse(fs.readFileSync(jsonPath, 'utf8'));
+    assert.strictEqual(payload.cvExtractedText, 'line1|line2');
+
+    fs.unlinkSync(dummyPdfPath);
+    fs.unlinkSync(jsonPath);
+    console.log('pdfExtractor newline filter test passed');
+  } catch (err) {
+    console.error(err);
+    process.exit(1);
+  }
+})();

--- a/tests/validateCV.test.js
+++ b/tests/validateCV.test.js
@@ -3,7 +3,9 @@ const assert = require('assert');
 // Sample data used in the test
 const jdJson = require('./fixtures/jd.json');
 const cvJson = require('./fixtures/cv.json');
-const cvText = cvJson.pages.map(page => page.text).join(' ');
+const cvText = cvJson.cvExtractedText
+  ? cvJson.cvExtractedText
+  : cvJson.pages.map(page => page.text).join(' ');
 
 // Stub models and helpers
 const Job = {};


### PR DESCRIPTION
## Summary
- add optional newline delimiter to PDF extractor
- adjust CV validation test to accept new CV text structure
- add unit test for PDF extractor newline filtering

## Testing
- `node tests/pdfExtractor.test.js && node tests/validateCV.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68a7d82f5680833090807d8ac9d841f8